### PR TITLE
Add cascading filter endpoints

### DIFF
--- a/src/main/java/com/rosettcompany/grupoCiencia/controller/FiltrosController.java
+++ b/src/main/java/com/rosettcompany/grupoCiencia/controller/FiltrosController.java
@@ -1,0 +1,47 @@
+package com.rosettcompany.grupoCiencia.controller;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.rosettcompany.grupoCiencia.repository.AulasEntity;
+import com.rosettcompany.grupoCiencia.repository.CiclosNormalizadosEntity;
+import com.rosettcompany.grupoCiencia.repository.Modalidad;
+import com.rosettcompany.grupoCiencia.service.FiltroServicio;
+
+@RestController
+@CrossOrigin(origins = "*", methods = { RequestMethod.GET, RequestMethod.POST, RequestMethod.PUT, RequestMethod.DELETE })
+@RequestMapping("/api/filtros")
+public class FiltrosController {
+
+    @Autowired
+    private FiltroServicio filtroServicio;
+
+    @GetMapping("/ciclos/sede/{idsede}")
+    public ResponseEntity<List<CiclosNormalizadosEntity>> ciclosPorSede(@PathVariable int idsede) {
+        List<CiclosNormalizadosEntity> data = filtroServicio.obtenerCiclosPorSede(idsede);
+        return new ResponseEntity<>(data, HttpStatus.OK);
+    }
+
+    @GetMapping("/modalidades/sede-ciclo/{idsede}/{idciclonormalizado}")
+    public ResponseEntity<List<Modalidad>> modalidadesPorSedeCiclo(@PathVariable int idsede,
+            @PathVariable int idciclonormalizado) {
+        List<Modalidad> data = filtroServicio.obtenerModalidadesPorSedeYCiclo(idsede, idciclonormalizado);
+        return new ResponseEntity<>(data, HttpStatus.OK);
+    }
+
+    @GetMapping("/aulas/sede-ciclo-modalidad/{idsede}/{idciclonormalizado}/{idmodalidad}")
+    public ResponseEntity<List<AulasEntity>> aulasPorSedeCicloModalidad(@PathVariable int idsede,
+            @PathVariable int idciclonormalizado, @PathVariable int idmodalidad) {
+        List<AulasEntity> data = filtroServicio.obtenerAulasPorSedeCicloModalidad(idsede, idciclonormalizado, idmodalidad);
+        return new ResponseEntity<>(data, HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/rosettcompany/grupoCiencia/repositoryI/AsignacionAulasRepositoryI.java
+++ b/src/main/java/com/rosettcompany/grupoCiencia/repositoryI/AsignacionAulasRepositoryI.java
@@ -1,6 +1,8 @@
 package com.rosettcompany.grupoCiencia.repositoryI;
 
-import org.springframework.data.jpa.repository.query.Procedure;
+import java.util.List;
+
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -9,5 +11,14 @@ import com.rosettcompany.grupoCiencia.repository.AsignacionAulasEntity;
 
 
 @Repository
-public interface AsignacionAulasRepositoryI extends CrudRepository<AsignacionAulasEntity, Integer>{ 
+public interface AsignacionAulasRepositoryI extends CrudRepository<AsignacionAulasEntity, Integer>{
+
+    @Query(value = "SELECT DISTINCT idciclonormalizado FROM asignacion_aulas WHERE idsede = :idsede", nativeQuery = true)
+    List<Integer> findCiclosBySede(@Param("idsede") int idsede);
+
+    @Query(value = "SELECT DISTINCT idmodalidad FROM asignacion_aulas WHERE idsede = :idsede AND idciclonormalizado = :idciclonormalizado", nativeQuery = true)
+    List<Integer> findModalidadesBySedeAndCiclo(@Param("idsede") int idsede, @Param("idciclonormalizado") int idciclonormalizado);
+
+    @Query(value = "SELECT DISTINCT idaula FROM asignacion_aulas WHERE idsede = :idsede AND idciclonormalizado = :idciclonormalizado AND idmodalidad = :idmodalidad", nativeQuery = true)
+    List<Integer> findAulasBySedeCicloModalidad(@Param("idsede") int idsede, @Param("idciclonormalizado") int idciclonormalizado, @Param("idmodalidad") int idmodalidad);
 }

--- a/src/main/java/com/rosettcompany/grupoCiencia/service/FiltroServicio.java
+++ b/src/main/java/com/rosettcompany/grupoCiencia/service/FiltroServicio.java
@@ -1,0 +1,58 @@
+package com.rosettcompany.grupoCiencia.service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.rosettcompany.grupoCiencia.repository.AulasEntity;
+import com.rosettcompany.grupoCiencia.repository.CiclosNormalizadosEntity;
+import com.rosettcompany.grupoCiencia.repository.Modalidad;
+import com.rosettcompany.grupoCiencia.repositoryI.AsignacionAulasRepositoryI;
+import com.rosettcompany.grupoCiencia.repositoryI.AulasRepositoryI;
+import com.rosettcompany.grupoCiencia.repositoryI.CiclosNormalizadosRepositoryI;
+import com.rosettcompany.grupoCiencia.repositoryI.ModalidadRepositoryI;
+
+@Service
+public class FiltroServicio {
+
+    @Autowired
+    private AsignacionAulasRepositoryI asignacionAulasRepository;
+
+    @Autowired
+    private CiclosNormalizadosRepositoryI ciclosRepository;
+
+    @Autowired
+    private ModalidadRepositoryI modalidadRepository;
+
+    @Autowired
+    private AulasRepositoryI aulasRepository;
+
+    public List<CiclosNormalizadosEntity> obtenerCiclosPorSede(int idsede) {
+        List<Integer> ids = asignacionAulasRepository.findCiclosBySede(idsede);
+        List<CiclosNormalizadosEntity> ciclos = new ArrayList<>();
+        for(Integer id : ids) {
+            ciclosRepository.findById(id).ifPresent(ciclos::add);
+        }
+        return ciclos;
+    }
+
+    public List<Modalidad> obtenerModalidadesPorSedeYCiclo(int idsede, int idciclonormalizado) {
+        List<Integer> ids = asignacionAulasRepository.findModalidadesBySedeAndCiclo(idsede, idciclonormalizado);
+        List<Modalidad> modalidades = new ArrayList<>();
+        for(Integer id : ids) {
+            modalidadRepository.findById(id).ifPresent(modalidades::add);
+        }
+        return modalidades;
+    }
+
+    public List<AulasEntity> obtenerAulasPorSedeCicloModalidad(int idsede, int idciclonormalizado, int idmodalidad) {
+        List<Integer> ids = asignacionAulasRepository.findAulasBySedeCicloModalidad(idsede, idciclonormalizado, idmodalidad);
+        List<AulasEntity> aulas = new ArrayList<>();
+        for(Integer id : ids) {
+            aulasRepository.findById(id).ifPresent(aulas::add);
+        }
+        return aulas;
+    }
+}


### PR DESCRIPTION
## Summary
- add queries to `AsignacionAulasRepositoryI`
- add `FiltroServicio` service with logic to obtain ciclos, modalidades and aulas
- expose new REST endpoints in `FiltrosController`

## Testing
- `mvn -q test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687819bf0ba08321abaaa6b096a81951